### PR TITLE
Diff sets optimize

### DIFF
--- a/reladiff/hashdiff_tables.py
+++ b/reladiff/hashdiff_tables.py
@@ -2,7 +2,7 @@ import os
 from numbers import Number
 import logging
 from collections import defaultdict
-from typing import Iterator
+from typing import Iterator, Any, List, Tuple
 from operator import attrgetter
 
 from dataclasses import dataclass, field
@@ -26,7 +26,7 @@ DEFAULT_BISECTION_FACTOR = 32
 logger = logging.getLogger("hashdiff_tables")
 
 
-def diff_sets(a: set, b: set) -> Iterator:
+def diff_sets(a: List[Tuple[Any, ...]], b: List[Tuple[Any, ...]]) -> Iterator:
     sa = set(a)
     sb = set(b)
 

--- a/reladiff/hashdiff_tables.py
+++ b/reladiff/hashdiff_tables.py
@@ -1,7 +1,7 @@
 import os
 from numbers import Number
 import logging
-from collections import defaultdict
+from itertools import chain
 from typing import Iterator, Any, List, Tuple
 from operator import attrgetter
 
@@ -32,16 +32,10 @@ def diff_sets(a: List[Tuple[Any, ...]], b: List[Tuple[Any, ...]]) -> Iterator:
 
     # The first item is always the key (see TableDiffer.relevant_columns)
     # TODO update to consider compound keys
-    d = defaultdict(list)
-    for row in a:
-        if row not in sb:
-            d[row[0]].append(("-", row))
-    for row in b:
-        if row not in sa:
-            d[row[0]].append(("+", row))
-
-    for _k, v in sorted(d.items(), key=lambda i: i[0]):
-        yield from v
+    yield from sorted(
+        chain((("-", item) for item in sa - sb),
+              (("+", item) for item in sb - sa)), key=lambda i: i[1]
+    )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Fixed `diff_sets() `signature, and used set operators to find symmetric_difference.
The performance was improved by x1.8 on local benchmarks of various dataset sizes (1,000, 5,000, and 50,000 rows).

Some thoughts - do we need the results to be sorted by key?
I know it's convenient in the log, but maybe we can add an option to skip the sort in cases where it's irrelevant? (for example, writing the diffs to the database and analyzing them with SQL, when a big number of diffs is expected)
