### PR TITLE
Allow comparison of String_UUID and Text

### DIFF
--- a/reladiff/hashdiff_tables.py
+++ b/reladiff/hashdiff_tables.py
@@ -117,7 +117,10 @@ class HashDiffer(TableDiffer):
 
             elif isinstance(col1, ColType_UUID):
                 if not isinstance(col2, ColType_UUID):
-                    raise TypeError(f"Incompatible types for column '{c1}':  {col1} <-> {col2}")
+                    if isinstance(col1, StringType) and isinstance(col2, StringType):
+                        pass  # Allow String_UUID to be compared to Text.
+                    else:
+                        raise TypeError(f"Incompatible types for column '{c1}':  {col1} <-> {col2}")
 
             elif isinstance(col1, StringType):
                 if not isinstance(col2, StringType):


### PR DESCRIPTION
After switching from data-diff to reladiff, one of our tables started failing with

>TypeError: Incompatible types for column 'the_column_name':  String_UUID() <-> Text()

As far as I can tell, the root cause is that [this code in sqeleton/databases/base.py](https://github.com/erezsh/sqeleton/blob/8655be43096dd6610c4ed8b5f9713f9a97670e7e/sqeleton/databases/base.py#L523-L534) uses sampling to determine if a column is String_UUID. But when such a column is nullable, it depends on chance if the sample contains NULL values. If it does, sqeleton will use the Text type, otherwise it will use String_UUID.

This change ensures that such columns can be compared reliably. I'm not sure if the is the best way to do it, but in our internal testing it looks good.