### PR TITLE
Allow to initialize connection externally (reuse same connection)

### DIFF
--- a/reladiff/__init__.py
+++ b/reladiff/__init__.py
@@ -22,7 +22,7 @@ def connect_to_table(
     """Connects to the given database, and creates a TableSegment instance
 
     Parameters:
-        db_info: Either a URI string, dict of connection options or a reladiff connection object.
+        db_info: Either a URI string, dict of connection options or a reladiff AbstractDatabase type.
         table_name: Name of the table as a string, or a tuple that signifies the path.
         key_columns: Names of the key columns
         thread_count: Number of threads for this connection (only if using a threadpooled db implementation)

--- a/reladiff/__init__.py
+++ b/reladiff/__init__.py
@@ -13,7 +13,7 @@ __version__ = "0.5.3"
 
 
 def connect_to_table(
-    db_info: Union[str, dict, object],
+    db_info: Union[str, dict, AbstractDatabase],
     table_name: Union[DbPath, str],
     key_columns: Union[str, Sequence[str]] = ("id",),
     thread_count: Optional[int] = 1,

--- a/reladiff/__init__.py
+++ b/reladiff/__init__.py
@@ -1,6 +1,6 @@
 from typing import Sequence, Tuple, Iterable, Optional, Union
 
-from sqeleton.abcs import DbTime, DbPath
+from sqeleton.abcs import DbTime, DbPath, AbstractDatabase
 
 from .databases import connect
 from .diff_tables import Algorithm, TableDiffer, DiffResultWrapper
@@ -34,7 +34,7 @@ def connect_to_table(
         key_columns = (key_columns,)
     if isinstance(db_info,str) or isinstance(db_info,dict):
         db = connect(db_info, thread_count=thread_count)
-    elif isinstance(db_info, object):
+    elif isinstance(db_info, AbstractDatabase):
         db = db_info
 
     if isinstance(table_name, str):

--- a/reladiff/__init__.py
+++ b/reladiff/__init__.py
@@ -13,7 +13,7 @@ __version__ = "0.5.3"
 
 
 def connect_to_table(
-    db_info: Union[str, dict],
+    db_info: Union[str, dict, object],
     table_name: Union[DbPath, str],
     key_columns: Union[str, Sequence[str]] = ("id",),
     thread_count: Optional[int] = 1,
@@ -22,7 +22,7 @@ def connect_to_table(
     """Connects to the given database, and creates a TableSegment instance
 
     Parameters:
-        db_info: Either a URI string, or a dict of connection options.
+        db_info: Either a URI string, dict of connection options or a reladiff connection object.
         table_name: Name of the table as a string, or a tuple that signifies the path.
         key_columns: Names of the key columns
         thread_count: Number of threads for this connection (only if using a threadpooled db implementation)
@@ -32,8 +32,10 @@ def connect_to_table(
     """
     if isinstance(key_columns, str):
         key_columns = (key_columns,)
-
-    db = connect(db_info, thread_count=thread_count)
+    if isinstance(db_info,str) or isinstance(db_info,dict):
+        db = connect(db_info, thread_count=thread_count)
+    elif isinstance(db_info, object):
+        db = db_info
 
     if isinstance(table_name, str):
         table_name = db.parse_table_name(table_name)

--- a/reladiff/__init__.py
+++ b/reladiff/__init__.py
@@ -32,10 +32,10 @@ def connect_to_table(
     """
     if isinstance(key_columns, str):
         key_columns = (key_columns,)
-    if isinstance(db_info,str) or isinstance(db_info,dict):
-        db = connect(db_info, thread_count=thread_count)
-    elif isinstance(db_info, AbstractDatabase):
+    if isinstance(db_info, AbstractDatabase):
         db = db_info
+    else:
+        db = connect(db_info, thread_count=thread_count)
 
     if isinstance(table_name, str):
         table_name = db.parse_table_name(table_name)


### PR DESCRIPTION
Hey, 
I have a wrapper around reladiff, and i do some pre-processing before starting rela-diff process. When using snowflake externalbrowser auth, it has to authenticate at least two times, as connect_to_table() only accepts configuration, and will initialize a new connection against the database.This PR introduce a small change, that allows to pass an externally initialized  reladiff connection. 

Example:
```python
from reladiff import connect as reladiff_connect
connection = reladiff_connect(self.connection_string)
rowcount = connection.query("SELECT COUNT(1) from TABLE")

source_conn = connect_to_table(connection, source_table, pks)
```