### PR TITLE
Feat #70: Add `transform_columns` for on-the-fly value adjustments during diff

### DIFF
--- a/reladiff/__init__.py
+++ b/reladiff/__init__.py
@@ -129,6 +129,11 @@ def diff_tables(
         them directly when creating each :class:`TableSegment`.
 
     Note:
+        Column transformations using SQL expressions can be configured using the `transform_columns` attribute when creating
+        the :class:`TableSegment` instances for `table1` and `table2`. As transformations are typically specific to either
+        the source or target database, this parameter is not overridden directly in `diff_tables`.
+
+    Note:
         It is recommended to call .close() on the returned object when done, to release thread-pool. Alternatively, you may use it as a context manager.
 
     Example:

--- a/reladiff/joindiff_tables.py
+++ b/reladiff/joindiff_tables.py
@@ -314,13 +314,8 @@ class JoinDiffer(TableDiffer):
         a = table1.make_select()
         b = table2.make_select()
 
-        def get_expr(table_alias, col_name, transform_dict):
-            if col_name in transform_dict:
-                return Code(transform_dict[col_name])
-            else:
-                return table_alias[col_name]
-
         # Get transformed expressions for both tables
+        # Displayed output value also transformed to be similar with Hashdiffer
         is_diff_cols = {}
         a_cols = {}
         b_cols = {}

--- a/reladiff/table_segment.py
+++ b/reladiff/table_segment.py
@@ -258,7 +258,7 @@ class TableSegment:
     @property
     def _relevant_columns_repr(self) -> List[Expr]:
         expressions = []
-        for c in self.relevant_columns: #smks-fix
+        for c in self.relevant_columns:
             if c in self.transform_columns:
                 transform_expr = self.transform_columns[c]
                 expressions.append(NormalizeAsString(Code(transform_expr.format(column=this[c])), self._schema[c]))


### PR DESCRIPTION
### Motivation:

Comparing data between different database systems (like Oracle and PostgreSQL) or even within the same system often requires minor, database-specific transformations to make column values truly comparable. Examples include adjusting timezones, applying string functions, or rounding numeric values.

Previously, achieving this required creating temporary views or pre-transforming data, adding complexity and impossible in restricted environments

### Solution:

This PR introduces a new `transform_columns` parameter to the `TableSegment` class. This parameter accepts a dictionary where:

*   **Keys** are the original column names in the table segment.
*   **Values** are raw SQL string expressions representing the transformation to be applied to that column *during the diff process*. The SQL syntax **must be valid for the database associated with the specific `TableSegment`**.

This allows users to specify minor adjustments directly within the `reladiff` configuration, eliminating the need for external setup.

### Examples of `transform_columns` Usage:

Here's how you might define `transform_columns` for different scenarios:

```python
# Example for an Oracle TableSegment
oracle_transforms = {
    "AMOUNT": "ROUND(AMOUNT, 2)",
    "LEGACY_ID": "TO_CHAR(LEGACY_ID)",
    "DESCRIPTION": "SUBSTR(DESCRIPTION, 1, 10)",
    "EVENT_TIMESTAMP": "CAST(EVENT_TIMESTAMP AT TIME ZONE 'UTC' AS TIMESTAMP)",
    "USER_NAME": "TRIM(USER_NAME)",
    "ACTIVE_FLAG": "CASE WHEN ACTIVE_FLAG = 'Y' THEN 1 ELSE 0 END"
}

# Example for a PostgreSQL TableSegment
postgres_transforms = {
    "amount": "ROUND(amount, 2)",
    "legacy_id": "CAST(legacy_id AS TEXT)", # or "legacy_id::TEXT"
    "description": "SUBSTRING(description FROM 1 FOR 10)",
    "event_timestamp": "event_timestamp AT TIME ZONE 'America/New_York' AT TIME ZONE 'UTC'",
    "user_name": "TRIM(user_name)",
    "active_flag": "CAST(active_flag AS INTEGER)"
}
```

When creating `TableSegment` objects:
```
src_segment = TableSegment(..., transform_columns=oracle_transforms)
tgt_segment = TableSegment(..., transform_columns=postgres_transforms)
```

### Implementation Details:

*   **`TableSegment`:**
    *   Added the `transform_columns: Dict[str, str]` attribute to store the transformation rules provided by the user.

*   **`HashDiffer`:**
    *   Modified the generation of expressions used for checksum calculation (`_relevant_columns_repr`) and final value fetching (`get_values`).
    *   If a column name exists in `transform_columns`, the provided SQL string is embedded using `sqeleton.queries.Code()` instead of the original column reference (`this[col]`).
    *   `NormalizeAsString` is applied to the result (either the original column or the transformed `Code`) to ensure consistent string representation for hashing and comparison.

*   **`JoinDiffer`:**
    *   Modified the `_create_outer_join` method.
    *   Within the `OUTER JOIN` query, for each compared column, it now checks if a transformation exists in `transform_columns`.
    *   If a transformation exists, `sqeleton.queries.Code(transformation_string)` is used; otherwise, the original column reference (`a[c1]`/`b[c2]`) is used.
    *   The comparison logic (`is_distinct_from`) and the selected output columns (`a_cols`, `b_cols`) now operate on the result of this potentially transformed expression, wrapped in `NormalizeAsString` using the original column's schema type for correct formatting.
*   **Unified Output:** Both `HashDiffer` and `JoinDiffer` will now output the *transformed* values for differing rows, providing a consistent representation of the data as it was compared.