### PR TITLE
Fix issue 81

### DIFF
--- a/reladiff/hashdiff_tables.py
+++ b/reladiff/hashdiff_tables.py
@@ -2,7 +2,7 @@ import os
 from functools import cmp_to_key
 from numbers import Number
 import logging
-from typing import Iterator, Sequence
+from typing import Iterator, Sequence, Tuple
 from operator import attrgetter
 from collections import Counter
 from itertools import chain
@@ -40,7 +40,7 @@ def compare_element(a, b):
     return 1
 
 
-def compare(a: tuple[str, Sequence], b: tuple[str, Sequence]) -> int:
+def compare(a: Tuple[str, Sequence], b: Tuple[str, Sequence]) -> int:
     """Compare two sequences of the same length.
 
     Compare a and b until the first element a[1][i] differs from b[1][i].

--- a/tests/test_diff_tables.py
+++ b/tests/test_diff_tables.py
@@ -6,7 +6,7 @@ import unittest
 from sqeleton.queries import table, this, commit
 from sqeleton.utils import ArithAlphanumeric, numberToAlphanum
 
-from reladiff.hashdiff_tables import HashDiffer
+from reladiff.hashdiff_tables import HashDiffer, compare_element, diff_sets
 from reladiff.joindiff_tables import JoinDiffer
 from reladiff.table_segment import TableSegment, split_space, Vector
 from reladiff import databases as db
@@ -1071,3 +1071,29 @@ class TestCompoundKeyAlphanum(DiffTestCase):
         self.assertEqual(diff, [("-", (uuid, "9", "9")), ("+", (uuid, "9000", "9"))])
 
         self.assertRaises(ValueError, list, differ.diff_tables(aa, a))
+
+
+class TestDiffSets(unittest.TestCase):
+    def test_compare_element(self):
+        self.assertEqual(compare_element(None, 1), -1)
+        self.assertEqual(compare_element(1, 2), -1)
+        self.assertEqual(compare_element(None, 2), -1)
+        self.assertEqual(compare_element(None, None), 0)
+        self.assertEqual(compare_element(1, 1), 0)
+        self.assertEqual(compare_element(2, 2), 0)
+        self.assertEqual(compare_element(1, None), 1)
+        self.assertEqual(compare_element(2, 1), 1)
+        self.assertEqual(compare_element(2, None), 1)
+        self.assertEqual(compare_element(None, ''), -1)
+        self.assertEqual(compare_element('', ''), 0)
+        self.assertEqual(compare_element('', None), 1)
+
+    def test_diff_sets(self):
+        res = diff_sets([(1, None)], [(1, '')], skip_sort_results=False, duplicate_rows_support=True)
+        self.assertSequenceEqual(res, [('-', (1, None)), ('+', (1, ''))])
+
+        res = diff_sets([(1, '')], [(1, None)], skip_sort_results=False, duplicate_rows_support=True)
+        self.assertSequenceEqual(res, [('+', (1, None)), ('-', (1, ''))])
+
+        res = diff_sets([(1, None), (1, None)], [(1, None)], skip_sort_results=False, duplicate_rows_support=True)
+        self.assertSequenceEqual(res, [('-', (1, None))])


### PR DESCRIPTION
Fix "HashDiffer may fail if differences between tables contain None and non-None values" which causes "TypeError: '<' not supported between instances of 'str' and 'NoneType'".